### PR TITLE
Change badges to images to allow for size adjustment on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,13 @@ This wireframe was made using Invision Studio
 
 #### Custom Badges
 To enhance the user experience, custom badges for IntrepEd were made using Adobe Illustrator.
-![Classroom Management](https://user-images.githubusercontent.com/47537744/72037195-7df6e780-325a-11ea-862a-0cb271d35407.png)
-![Culturally Responsive Teaching](https://user-images.githubusercontent.com/47537744/72037240-a8e13b80-325a-11ea-8ead-dc04649d0c48.png)
-![Data Driven Instruction](https://user-images.githubusercontent.com/47537744/72037298-e0e87e80-325a-11ea-8705-74c23bc436da.png)
-![Engagement Strategies](https://user-images.githubusercontent.com/47537744/72037336-fa89c600-325a-11ea-9e4f-d0a14c5f8b2f.png)
-![Lesson Planning](https://user-images.githubusercontent.com/47537744/72037356-0f665980-325b-11ea-8f2c-bcc540f7538f.png)
+
+<img src="https://user-images.githubusercontent.com/47537744/72037195-7df6e780-325a-11ea-862a-0cb271d35407.png" width="200" height="200" alt="Classroom Management Badge, CM for short."/>
+<br>
+<img src="https://user-images.githubusercontent.com/47537744/72037240-a8e13b80-325a-11ea-8ead-dc04649d0c48.png" width="200" height="200" alt="Culturally Responsive Teaching badge, CLDE for short"/>
+<br>
+<img src="https://user-images.githubusercontent.com/47537744/72037298-e0e87e80-325a-11ea-8705-74c23bc436da.png" width="250" height="200" alt="Data Driven Instruction badge, DDI for short."/>
+<br>
+<img src="https://user-images.githubusercontent.com/47537744/72037336-fa89c600-325a-11ea-9e4f-d0a14c5f8b2f.png" width="200" height="200" alt="Engagement Strategies Badge, ES for short."/>
+<br>
+<img src="https://user-images.githubusercontent.com/47537744/72037356-0f665980-325b-11ea-8f2c-bcc540f7538f.png" width="250" height="200" alt="Lesson Planning badge, LP for short."/>


### PR DESCRIPTION
#### What's this PR do?
* Changes the badges to images to allow for smaller sizing on ReadMe
#### Where should the reviewer start?
* Readme
#### How should this be manually tested?
* View Readme
#### Any background context you want to provide?
* NA
#### What are the relevant tickets?
* NA
#### Screenshots (if appropriate):
<img width="534" alt="Screen Shot 2020-01-20 at 6 59 20 PM" src="https://user-images.githubusercontent.com/47537744/72769229-360b8500-3bb7-11ea-9b48-5f8f36cd19a3.png">

#### Questions:
* If you think they would look better a different size let me know
#### Notes: 
* The picture above is a sample of the sizes. The reason they are not all perfectly aligned is because the DDI looks better slight wider than taller

