### PR TITLE
Fix data category bug

### DIFF
--- a/src/components/CourseCompletedModal/CourseCompletedModal.js
+++ b/src/components/CourseCompletedModal/CourseCompletedModal.js
@@ -20,11 +20,23 @@ const CourseCompletedModal = ({modalState, toggleModal, category}) => {
       return Classroom
     } else if (category === 'Culturally') {
       return Culturally
-    } else if (category === 'Data') {
+    } else if (category === 'Data-Driven') {
       return Data
     } else {
       return Effective
     }
+  }
+
+  const determineBadgeProgress = () => {
+    if(category === "Data-Driven") {
+      category = "Data"
+    }
+    if (badgeProgress[category].length === []) {
+      return 0;
+    } else {
+      return badgeProgress[category].length;
+    }
+
   }
 
   return (
@@ -48,7 +60,7 @@ const CourseCompletedModal = ({modalState, toggleModal, category}) => {
     >
       <section className='course-complete-summary'>
         <h1>Congratulations!</h1>
-        <p>You have completed {badgeProgress[category].length}/5 courses required for your next badge!</p>
+        <p>You have completed {determineBadgeProgress()}/5 courses required for your next badge!</p>
         <img src={determineBadgeIcon()} alt={category}/>
         <button
           className='acknowlege-summary'

--- a/src/components/CourseDetail/CourseDetail.js
+++ b/src/components/CourseDetail/CourseDetail.js
@@ -33,7 +33,7 @@ const CourseDetail = ({ id }) => {
   }
 
   const updateBadges = async () => {
-    const shortHandCategory = currentCourse.category.split(' ')[0]
+    const shortHandCategory = currentCourse.category.split(' ')[0];
     const updatedBadges = {
       ...badgeProgress,
       [shortHandCategory]:[...badgeProgress[shortHandCategory], currentCourse.id]


### PR DESCRIPTION
#### What's this PR do?
* This PR adds a determineBadgeProgress method to catch the bug that was associated with the category "Data-Driven" vs "Data" due to naming in the redux store. 
#### Where should the reviewer start?
* The reviewer should start in CourseCompletedModal.js
#### How should this be manually tested?
* On the homepage try to watch one of the data-driven category videos
#### Any background context you want to provide?
* This fixes the bug, and will now allow for the data-driven category videos to be played. 
#### What are the relevant tickets?
* #64 
#### Screenshots (if appropriate):
* NA
#### Questions:
* NA
#### Notes: 
* NA

